### PR TITLE
Fix fragments of paths appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-connection-plugin",
-  "version": "0.2.3",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rete --build rete.config.js",
     "build:dev": "rete --build rete.config.js --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "author": "",
   "license": "ISC",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ function install(editor) {
     var picker = new Picker(editor)
 
     function pickOutput(output) {
-        if (output) {
+        if (output && !picker.output) {
             picker.output = output;
             return;
         }


### PR DESCRIPTION
When clicking an output multiple times, fragments of paths appeared and SVG elements were spawned for each click. This PR fixes that behavior.