### PR TITLE
Call preventDefault() in pointerDown()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ function install(editor: NodeEditor) {
             const { input, output } = flowEl;
             
             editor.view.container.dispatchEvent(new PointerEvent('pointermove', e));
+            e.preventDefault();
             e.stopPropagation();
             flow.start({ input, output }, input || output);
         }


### PR DESCRIPTION
Call `preventDefault()` in `pointerDown()` to prevent downstream mouse handlers from being triggered.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onpointerdown):
>If the pointerdown event isn't canceled through a call to preventDefault(), most user agents will fire a mousedown event, so that sites not using pointer events will work.

>Then the event's preventDefault() method is called to ensure that the mousedown event isn't triggered, potentially causing events to be handled twice if we had a handler for those events in case Pointer Event support is missing.

In our case, we had drag handlers whose `onDragStart()` was being triggered downstream of the pointerDown events used to connect nodes.

Note that a similar argument could be made for the `pointerUp()` function, but that wasn't required for our use case so I decided to keep this PR simple.